### PR TITLE
:key: tokenizer returns detailed token list with locations

### DIFF
--- a/__snapshots__/tokenizer.test.js.snap
+++ b/__snapshots__/tokenizer.test.js.snap
@@ -1,0 +1,463 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tokenizer matches a complex set command 1`] = `
+Array [
+  Object {
+    "end": 3,
+    "kind": "identifier",
+    "loc": Object {
+      "end": 3,
+      "start": 0,
+    },
+    "start": 0,
+    "value": "set",
+  },
+  Object {
+    "end": 4,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 3,
+        "line": 0,
+      },
+    },
+    "start": 3,
+    "value": " ",
+  },
+  Object {
+    "end": 5,
+    "kind": "identifier",
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 0,
+      },
+    },
+    "start": 4,
+    "value": "v",
+  },
+  Object {
+    "end": 6,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 6,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 5,
+        "line": 0,
+      },
+    },
+    "start": 5,
+    "value": " ",
+  },
+  Object {
+    "end": 7,
+    "kind": "openParen",
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 6,
+        "line": 0,
+      },
+    },
+    "start": 6,
+    "value": "(",
+  },
+  Object {
+    "end": 9,
+    "kind": "number",
+    "loc": Object {
+      "end": 9,
+      "start": 7,
+    },
+    "start": 7,
+    "value": "23",
+  },
+  Object {
+    "end": 10,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 10,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 9,
+        "line": 0,
+      },
+    },
+    "start": 9,
+    "value": " ",
+  },
+  Object {
+    "end": 11,
+    "kind": "plusSign",
+    "loc": Object {
+      "end": Object {
+        "column": 11,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 10,
+        "line": 0,
+      },
+    },
+    "start": 10,
+    "value": "+",
+  },
+  Object {
+    "end": 12,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 11,
+        "line": 0,
+      },
+    },
+    "start": 11,
+    "value": " ",
+  },
+  Object {
+    "end": 14,
+    "kind": "number",
+    "loc": Object {
+      "end": 14,
+      "start": 12,
+    },
+    "start": 12,
+    "value": "10",
+  },
+  Object {
+    "end": 15,
+    "kind": "closeParen",
+    "loc": Object {
+      "end": Object {
+        "column": 15,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 14,
+        "line": 0,
+      },
+    },
+    "start": 14,
+    "value": ")",
+  },
+]
+`;
+
+exports[`tokenizer matches a line command 1`] = `
+Array [
+  Object {
+    "end": 4,
+    "kind": "identifier",
+    "loc": Object {
+      "end": 4,
+      "start": 0,
+    },
+    "start": 0,
+    "value": "line",
+  },
+  Object {
+    "end": 5,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 0,
+      },
+    },
+    "start": 4,
+    "value": " ",
+  },
+  Object {
+    "end": 7,
+    "kind": "number",
+    "loc": Object {
+      "end": 7,
+      "start": 5,
+    },
+    "start": 5,
+    "value": "30",
+  },
+  Object {
+    "end": 8,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 8,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 7,
+        "line": 0,
+      },
+    },
+    "start": 7,
+    "value": " ",
+  },
+  Object {
+    "end": 10,
+    "kind": "number",
+    "loc": Object {
+      "end": 10,
+      "start": 8,
+    },
+    "start": 8,
+    "value": "21",
+  },
+  Object {
+    "end": 11,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 11,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 10,
+        "line": 0,
+      },
+    },
+    "start": 10,
+    "value": " ",
+  },
+  Object {
+    "end": 13,
+    "kind": "number",
+    "loc": Object {
+      "end": 13,
+      "start": 11,
+    },
+    "start": 11,
+    "value": "22",
+  },
+  Object {
+    "end": 14,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 14,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 13,
+        "line": 0,
+      },
+    },
+    "start": 13,
+    "value": " ",
+  },
+  Object {
+    "end": 16,
+    "kind": "number",
+    "loc": Object {
+      "end": 16,
+      "start": 14,
+    },
+    "start": 14,
+    "value": "50",
+  },
+]
+`;
+
+exports[`tokenizer matches a multiline set command 1`] = `
+Array [
+  Object {
+    "end": 3,
+    "kind": "identifier",
+    "loc": Object {
+      "end": 3,
+      "start": 0,
+    },
+    "start": 0,
+    "value": "set",
+  },
+  Object {
+    "end": 4,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 3,
+        "line": 0,
+      },
+    },
+    "start": 3,
+    "value": " ",
+  },
+  Object {
+    "end": 5,
+    "kind": "identifier",
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 0,
+      },
+    },
+    "start": 4,
+    "value": "v",
+  },
+  Object {
+    "end": 6,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 6,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 5,
+        "line": 0,
+      },
+    },
+    "start": 5,
+    "value": " ",
+  },
+  Object {
+    "end": 7,
+    "kind": "newline",
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 0,
+      },
+      "start": Object {
+        "column": 6,
+        "line": 0,
+      },
+    },
+    "start": 6,
+    "value": "
+",
+  },
+  Object {
+    "end": 8,
+    "kind": "openParen",
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "start": 7,
+    "value": "(",
+  },
+  Object {
+    "end": 10,
+    "kind": "number",
+    "loc": Object {
+      "end": 10,
+      "start": 8,
+    },
+    "start": 8,
+    "value": "23",
+  },
+  Object {
+    "end": 11,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 3,
+        "line": 1,
+      },
+    },
+    "start": 10,
+    "value": " ",
+  },
+  Object {
+    "end": 12,
+    "kind": "plusSign",
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "start": 11,
+    "value": "+",
+  },
+  Object {
+    "end": 13,
+    "kind": "whitespace",
+    "loc": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 5,
+        "line": 1,
+      },
+    },
+    "start": 12,
+    "value": " ",
+  },
+  Object {
+    "end": 15,
+    "kind": "number",
+    "loc": Object {
+      "end": 15,
+      "start": 13,
+    },
+    "start": 13,
+    "value": "10",
+  },
+  Object {
+    "end": 16,
+    "kind": "closeParen",
+    "loc": Object {
+      "end": Object {
+        "column": 9,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 8,
+        "line": 1,
+      },
+    },
+    "start": 15,
+    "value": ")",
+  },
+]
+`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbn",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "scripts": {
     "test": "jest"
   },

--- a/parser.js
+++ b/parser.js
@@ -1,1 +1,0 @@
-module.exports = () => ({})

--- a/parser.test.js
+++ b/parser.test.js
@@ -1,8 +1,0 @@
-const parser = require('./parser');
-
-describe('parser', () => {
-
-  it('imports something that always spews an object', () => {
-    expect(parser('paper 100')).toBeInstanceOf(Object)
-  })
-})

--- a/tokenizer.js
+++ b/tokenizer.js
@@ -1,0 +1,108 @@
+const tokenTypes = [
+  {kind: 'openParen', test: input => /^\($/.test(input)},
+  {kind: 'closeParen', test: input => /^\)$/.test(input)},
+  {kind: 'openBracket', test: input => /^\{$/.test(input)},
+  {kind: 'closeBracket', test: input => /^\}^/.test(input)},
+  {kind: 'questionMark', test: input => /^\?^/.test(input)},
+  {kind: 'identifier', test: input => /^[a-zA-Z]+$/.test(input)},
+  {kind: 'number', test: input => /^[0-9]+$/.test(input)},
+  {kind: 'plusSign', test: input => /^\+$/.test(input)},
+  {kind: 'minusSign', test: input => /^-$/.test(input)},
+  {kind: 'multiplySign', test: input => /^\*$/.test(input)},
+  {kind: 'divideSign', test: input => /^\/$/.test(input)},
+  {kind: 'newline', test: input => /^\n$/.test(input)},
+  {kind: 'whitespace', test: input => /^\s$/.test(input)},
+];
+
+const assignTokens = (token, index, allTokens) => {
+  const matchedTokens = tokenTypes.filter(type => type.test(token.value))[0]
+  const kind = matchedTokens
+    ? matchedTokens.kind
+    : 'unknown';
+
+  return Object.assign({}, token, {kind});
+}
+
+const mergeTokens = (output, currentToken, index, allTokens) => {
+  if (output.length === 0) {
+    return [currentToken];
+  } else {
+    const previous = output[output.length - 1];
+    if (previous.kind === currentToken.kind) {
+      const previousToken = output.pop();
+      const mergedToken = Object.assign({}, previousToken, {
+        value: previousToken.value + currentToken.value,
+        end: currentToken.end,
+        loc: {
+          start: previousToken.start,
+          end: currentToken.end,
+        }
+      })
+      output.push(mergedToken);
+    } else {
+      output.push(currentToken);
+    }
+    return output;
+  }
+}
+
+const withPositions = (output, current, idx, arr) => {
+  const firstToken = output.length === 0;
+  const previousToken = output[output.length - 1];
+  const previousLine = firstToken ? 0 : previousToken.loc.end.line;
+  const startsLine = firstToken ? true : previousToken.value === `\n`
+
+  const pos = {
+    start: firstToken
+      ? 0
+      : previousToken.end,
+    end: firstToken
+      ? current.value.length
+      : previousToken.end + current.value.length,
+    loc: {
+      start: {
+        line: firstToken
+          ? 0
+          : startsLine
+            ? previousLine + 1
+            : previousLine,
+        column: firstToken
+          ? 0
+          : startsLine
+            ? 0
+            : previousToken.loc.end.column,
+      },
+      end: {
+        line: firstToken
+          ? 0
+          : startsLine
+            ? previousLine + 1
+            : previousLine,
+        column: firstToken
+          ? current.value.length
+          : startsLine
+            ? current.value.length
+            : previousToken.loc.end.column + current.value.length,
+      }
+    }
+  };
+
+  const positioned = Object.assign({}, current, pos)
+  output.push(positioned)
+
+  return output
+}
+
+const toValues = value => ({value});
+
+const tokenize = input => {
+  const tokens = input
+    .split('')
+    .map(toValues)
+    .reduce(withPositions, [])
+    .map(assignTokens)
+    .reduce(mergeTokens, [])
+  return tokens;
+}
+
+module.exports = tokenize

--- a/tokenizer.test.js
+++ b/tokenizer.test.js
@@ -1,0 +1,22 @@
+const tokenizer = require('./tokenizer');
+
+describe('tokenizer', () => {
+
+  it('tokenizes a command with correct number of tokens', () => {
+    expect(tokenizer('paper 100')).toHaveLength(3);
+  });
+
+  it('matches a line command', () => {
+    expect(tokenizer('line 30 21 22 50')).toMatchSnapshot();
+  });
+
+  it('matches a complex set command', () => {
+    expect(tokenizer('set v (23 + 10)')).toMatchSnapshot();
+  })
+  it('tokenizes a set command', () => {
+    expect(tokenizer('set v (23 + 10)')).toHaveLength(11);
+  })
+  it('matches a multiline set command', () => {
+    expect(tokenizer(`set v \n(23 + 10)`)).toMatchSnapshot();
+  });
+})


### PR DESCRIPTION
Tokens are basically:

```javascript
type Token = 'identifier' | 'whitespace' | 'number' | 'unknown' |
  'openParen' | 'closeParen' | 'openBracket' | 'closeBracket' |
  'plusSign' | 'minusSign' | 'multiplySign' | 'divideSign';

tokens look like esprima-ish nodes:
{
  value: string,
  kind: TokenType,
  start: number,
  end: number,
  loc: {
    start: {
      column: number,
      line: number,
    },
    end: {
      column: number,
      line: number,
    },
  }
}
```